### PR TITLE
add repository to identify download library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,12 @@
             <id>nexus-ebi-snapshot-repo</id>
             <url>http://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-snapshots/</url>
         </repository>
+        <repository>
+            <!-- This repo is required for cpdetector (required by jmzidml->pride-xml-handler->xxindex->cpdetector) and related libraries -->
+            <!-- This is supplied here because of an HTTP 301 Permanent Redirect on the old URL that xxindex supplies, which breaks fresh builds. -->
+            <id>sammoa-group</id>
+            <url>https://nexus.nuiton.org/nexus/content/groups/sammoa-group/</url>
+        </repository>
     </repositories>
 
     <!--scm git config-->


### PR DESCRIPTION
This repo is required for cpdetector (required by jmzidml->pride-xml-handler->xxindex->cpdetector) and related libraries 
This is supplied here because of an HTTP 301 Permanent Redirect on the old URL that xxindex supplies, which breaks fresh builds. 