### PR TITLE
support for mzIdentML 1.3 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Currently, the jmzIdentML supports the two major mzIdentML versions:
 
 - [mzIdentML 1.1](https://www.psidev.info/mzidentml#mzIdentML1_1_1)
 - [mzIdentML 1.2](https://www.psidev.info/mzidentml#mzid12)
+- [mzIdentML 1.3](https://www.psidev.info/mzidentml#mzid13)
 
 ## jmzIdentML API
 

--- a/src/main/java/uk/ac/ebi/jmzidml/model/utils/ModelConstants.java
+++ b/src/main/java/uk/ac/ebi/jmzidml/model/utils/ModelConstants.java
@@ -50,6 +50,9 @@ public class ModelConstants {
     public static final String MZIDML_NS_1_2 = "http://psidev.info/psi/pi/mzIdentML/1.2";
     public static final String MZIDML_VERSION_1_2 = "1.2.0";
     public static final String MZIDML_SCHEMA_1_2 = "http://www.psidev.info/files/mzIdentML1.2.0.xsd";
+    public static final String MZIDML_NS_1_3 = "http://psidev.info/psi/pi/mzIdentML/1.3";
+    public static final String MZIDML_VERSION_1_3 = "1.3.0";
+    public static final String MZIDML_SCHEMA_1_3 = "http://www.psidev.info/files/mzIdentML1.3.0.xsd";
 
     private static Map<Class, QName> modelQNames = new HashMap<>();
 

--- a/src/main/java/uk/ac/ebi/jmzidml/model/utils/MzIdentMLVersion.java
+++ b/src/main/java/uk/ac/ebi/jmzidml/model/utils/MzIdentMLVersion.java
@@ -25,7 +25,9 @@ public enum MzIdentMLVersion {
     Version_1_1(ModelConstants.MZIDML_NS_1_1, ModelConstants.MZIDML_VERSION_1_1,
                 ModelConstants.MZIDML_SCHEMA_1_1),
     Version_1_2(ModelConstants.MZIDML_NS_1_2, ModelConstants.MZIDML_VERSION_1_2,
-                ModelConstants.MZIDML_SCHEMA_1_2);
+                ModelConstants.MZIDML_SCHEMA_1_2),
+    Version_1_3(ModelConstants.MZIDML_NS_1_3, ModelConstants.MZIDML_VERSION_1_3,
+                ModelConstants.MZIDML_SCHEMA_1_3);
 
     private final String MZIDML_NS;
     private final String MZIDML_VERSION;
@@ -107,6 +109,8 @@ public enum MzIdentMLVersion {
             return Version_1_1;
         } else if (ver.equals("1.2")) {
             return Version_1_2;
+        } else if (ver.equals("1.3")) {
+            return Version_1_3;
         } else {
             return null;
         }

--- a/src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLMarshaller.java
+++ b/src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLMarshaller.java
@@ -183,7 +183,7 @@ public class MzIdentMLMarshaller {
             } else {
                 if (logger.isDebugEnabled()) logger.debug("Object '" + object.getClass().getName() +
                                                           "' is root - exporting complete XML-file.");
-                marshallRoot((MzIdentML)object, out, UUID.randomUUID().toString(), encoding, version);
+                marshallRoot((MzIdentML)object, out, encoding, UUID.randomUUID().toString(), version);
                 return;
             }
 

--- a/src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLMarshaller.java
+++ b/src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLMarshaller.java
@@ -26,6 +26,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.UUID;
 import javax.xml.bind.annotation.XmlType;
 
@@ -128,6 +129,19 @@ public class MzIdentMLMarshaller {
         this.marshal(object, out, "UTF-8", version);
     }
 
+    /**
+     * Marshals the root {@link MzIdentML} object to the provided {@link Writer}, manually writing the
+     * XML declaration {@link MzIdentMLMarshaller#createXmlHeader()}, the root 
+     * <MzIdentML> {@link #createMzIdentMLStartTag(java.lang.String)}  start tag with appropriate version, 
+     * namespace, and schema attributes, and then serializing all sub-elements individually.
+     *
+     * @param root the {@code MzIdentML} object to marshal as the document root
+     * @param out the {@code Writer} to which the XML content will be written
+     * @param encoding the XML encoding to declare in the header (e.g., "UTF-8")
+     * @param id the value for the {@code id} attribute on the root <MzIdentML> element
+     * @param version the {@code MzIdentMLVersion} specifying schema namespace and version attributes
+     * @throws IllegalStateException if an error occurs during marshalling
+     */
     public void marshallRoot(MzIdentML root, Writer out, String encoding, String id, MzIdentMLVersion version) {
         this.version = version;
         try {
@@ -135,7 +149,6 @@ public class MzIdentMLMarshaller {
 
             out.write("\n");
 
-            // I replaced all 1.1 with 1.2 in the start tag - I am not sure if really all need to be replaced
             out.write(this.createMzIdentMLStartTag(id) + "\n");
 
             XmlType xmlType = root.getClass().getAnnotation(XmlType.class);
@@ -149,6 +162,7 @@ public class MzIdentMLMarshaller {
                 }
             }            
             out.write(this.createMzIdentMLClosingTag());
+            out.flush();
         } catch (NoSuchFieldException | SecurityException | IllegalAccessException | IOException e) {
             logger.error("MzMLMarshaller.marshall", e);
             throw new IllegalStateException("Error while marshalling object:" + root.toString());

--- a/src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLMarshaller.java
+++ b/src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLMarshaller.java
@@ -22,6 +22,7 @@ import javax.xml.stream.XMLStreamWriter;
 import java.io.*;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 
@@ -151,6 +152,11 @@ public class MzIdentMLMarshaller {
             } else {
                 if (logger.isDebugEnabled()) logger.debug("Object '" + object.getClass().getName() +
                                                           "' will be treated as fragment.");
+                marshaller.setProperty(Marshaller.JAXB_SCHEMA_LOCATION,
+                        version.getNameSpace() + " " + version.getSchema());
+                if (((MzIdentML) object).getCreationDate() == null) {
+                    ((MzIdentML) object).setCreationDate(Calendar.getInstance());
+                }
             }
 
             QName aQName = version.getQNameForClass(object.getClass());

--- a/src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLMarshaller.java
+++ b/src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLMarshaller.java
@@ -20,11 +20,14 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
 import java.io.*;
+import java.lang.reflect.Field;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.UUID;
+import javax.xml.bind.annotation.XmlType;
 
 import javax.xml.namespace.NamespaceContext;
 
@@ -125,6 +128,34 @@ public class MzIdentMLMarshaller {
         this.marshal(object, out, "UTF-8", version);
     }
 
+    public void marshallRoot(MzIdentML root, Writer out, String encoding, String id, MzIdentMLVersion version) {
+        this.version = version;
+        try {
+            out.write(this.createXmlHeader(encoding));
+
+            out.write("\n");
+
+            // I replaced all 1.1 with 1.2 in the start tag - I am not sure if really all need to be replaced
+            out.write(this.createMzIdentMLStartTag(id) + "\n");
+
+            XmlType xmlType = root.getClass().getAnnotation(XmlType.class);
+            for (String prop : xmlType.propOrder()) {
+                Field field = MzIdentML.class.getDeclaredField(prop);
+                field.setAccessible(true);
+                Object value = field.get(root);
+                if (value != null) {
+                    // Marshal each sub-element individually
+                    this.marshal((MzIdentMLObject)value, out);
+                }
+            }            
+            out.write(this.createMzIdentMLClosingTag());
+        } catch (NoSuchFieldException | SecurityException | IllegalAccessException | IOException e) {
+            logger.error("MzMLMarshaller.marshall", e);
+            throw new IllegalStateException("Error while marshalling object:" + root.toString());
+        }
+    }
+    
+    
     /**
      * Marshal an MzIdentMLObject to output in accordance with specified mzIdentML version.
      * @param <T> Subtype of MzidentMLObject
@@ -148,15 +179,10 @@ public class MzIdentMLMarshaller {
             if (!(object instanceof MzIdentML)) {
                 marshaller.setProperty(Constants.JAXB_FRAGMENT_PROPERTY, true);
                 if (logger.isDebugEnabled()) logger.debug("Object '" + object.getClass().getName() +
-                                                          "' will be treated as root element.");
-            } else {
-                if (logger.isDebugEnabled()) logger.debug("Object '" + object.getClass().getName() +
                                                           "' will be treated as fragment.");
-                marshaller.setProperty(Marshaller.JAXB_SCHEMA_LOCATION,
-                        version.getNameSpace() + " " + version.getSchema());
-                if (((MzIdentML) object).getCreationDate() == null) {
-                    ((MzIdentML) object).setCreationDate(Calendar.getInstance());
-                }
+            } else {
+                marshallRoot((MzIdentML)object, out, UUID.randomUUID().toString(), encoding, version);
+                return;
             }
 
             QName aQName = version.getQNameForClass(object.getClass());
@@ -222,6 +248,10 @@ public class MzIdentMLMarshaller {
         return "<?xml version=\"1.0\" encoding=\"" + encoding + "\"?>";
     }
 
+    public String createXmlHeader(String encoding) {
+        return "<?xml version=\"1.0\" encoding=\"" + encoding + "\"?>";
+    }
+    
     public String createMzIdentMLStartTag(String id) {
         StringBuilder sb = new StringBuilder();
 

--- a/src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLMarshaller.java
+++ b/src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLMarshaller.java
@@ -181,6 +181,8 @@ public class MzIdentMLMarshaller {
                 if (logger.isDebugEnabled()) logger.debug("Object '" + object.getClass().getName() +
                                                           "' will be treated as fragment.");
             } else {
+                if (logger.isDebugEnabled()) logger.debug("Object '" + object.getClass().getName() +
+                                                          "' is root - exporting complete XML-file.");
                 marshallRoot((MzIdentML)object, out, UUID.randomUUID().toString(), encoding, version);
                 return;
             }

--- a/src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLUnmarshaller.java
+++ b/src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLUnmarshaller.java
@@ -83,6 +83,8 @@ public class MzIdentMLUnmarshaller {
             this.mzIdentVersion = MzIdentMLVersion.Version_1_1;
         } else if (this.mzidVersion.startsWith("1.2")){
             this.mzIdentVersion = MzIdentMLVersion.Version_1_2;
+        } else if (this.mzidVersion.startsWith("1.3")){
+            this.mzIdentVersion = MzIdentMLVersion.Version_1_3;
         } else {
             throw new IllegalStateException("The mzIdentML file version is not recognized!");
         }

--- a/src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLUnmarshaller.java
+++ b/src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLUnmarshaller.java
@@ -81,9 +81,9 @@ public class MzIdentMLUnmarshaller {
         this.cache = null;
         if (this.getMzIdentMLVersion().startsWith("1.1")){
             this.mzIdentVersion = MzIdentMLVersion.Version_1_1;
-        } else if (this.mzidVersion.startsWith("1.2")){
+        } else if (this.getMzIdentMLVersion().startsWith("1.2")){
             this.mzIdentVersion = MzIdentMLVersion.Version_1_2;
-        } else if (this.mzidVersion.startsWith("1.3")){
+        } else if (this.getMzIdentMLVersion().startsWith("1.3")){
             this.mzIdentVersion = MzIdentMLVersion.Version_1_3;
         } else {
             throw new IllegalStateException("The mzIdentML file version is not recognized!");

--- a/src/main/java/uk/ac/ebi/jmzidml/xml/util/EscapingXMLStreamWriter.java
+++ b/src/main/java/uk/ac/ebi/jmzidml/xml/util/EscapingXMLStreamWriter.java
@@ -86,7 +86,7 @@ public class EscapingXMLStreamWriter implements XMLStreamWriter {
 
     public void writeAttribute(String prefix, String namespaceUri, String localName, String value)
             throws XMLStreamException {
-        writer.writeAttribute("" , version.getNameSpace(), localName, EscapingXMLUtilities.escapeCharacters(value));
+        writer.writeAttribute("", version.getNameSpace(), localName, EscapingXMLUtilities.escapeCharacters(value));
     }
 
     public void writeAttribute(String namespaceUri, String localName, String value)

--- a/src/main/java/uk/ac/ebi/jmzidml/xml/util/EscapingXMLStreamWriter.java
+++ b/src/main/java/uk/ac/ebi/jmzidml/xml/util/EscapingXMLStreamWriter.java
@@ -86,7 +86,7 @@ public class EscapingXMLStreamWriter implements XMLStreamWriter {
 
     public void writeAttribute(String prefix, String namespaceUri, String localName, String value)
             throws XMLStreamException {
-        writer.writeAttribute(prefix, version.getNameSpace(), localName, EscapingXMLUtilities.escapeCharacters(value));
+        writer.writeAttribute("" , version.getNameSpace(), localName, EscapingXMLUtilities.escapeCharacters(value));
     }
 
     public void writeAttribute(String namespaceUri, String localName, String value)

--- a/src/main/java/uk/ac/ebi/jmzidml/xml/util/EscapingXMLStreamWriter.java
+++ b/src/main/java/uk/ac/ebi/jmzidml/xml/util/EscapingXMLStreamWriter.java
@@ -86,7 +86,7 @@ public class EscapingXMLStreamWriter implements XMLStreamWriter {
 
     public void writeAttribute(String prefix, String namespaceUri, String localName, String value)
             throws XMLStreamException {
-        writer.writeAttribute("", version.getNameSpace(), localName, EscapingXMLUtilities.escapeCharacters(value));
+        writer.writeAttribute(prefix, version.getNameSpace(), localName, EscapingXMLUtilities.escapeCharacters(value));
     }
 
     public void writeAttribute(String namespaceUri, String localName, String value)


### PR DESCRIPTION
### **User description**
*  Added version information for 1.3
* exporting the root element automatically adds the schema source location
  * if no creation date is defined it will be set to teh current date and time
*  changed EscapingXMLStreamWriter.writeAttribute that it does not export an empty prefix, as that seems to lead to conflicts in with writing a schema-source
   * not sure in how far the last change is correct, as I don't fully understand the intended use case for that filter however for me at least it works - only I don't use extra schema source anywhere


___

### **PR Type**
Enhancement


___

### **Description**
- Add support for mzIdentML version 1.3 schema

- Automatically set schema location and creation date for root elements

- Fix XML attribute writing to prevent empty prefix conflicts


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModelConstants.java</strong><dd><code>Add mzIdentML 1.3 constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/uk/ac/ebi/jmzidml/model/utils/ModelConstants.java

- Add namespace, version, and schema constants for mzIdentML 1.3


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/jmzIdentML/pull/20/files#diff-617107f551ec22eda53470358e0ab01b91b6350dbd33868ab3f9721c3134b147">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MzIdentMLVersion.java</strong><dd><code>Add Version_1_3 enum support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/uk/ac/ebi/jmzidml/model/utils/MzIdentMLVersion.java

<li>Add Version_1_3 enum entry with 1.3 constants<br> <li> Update getVersion method to handle "1.3" string input


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/jmzIdentML/pull/20/files#diff-b1c20e7320d0e038aa7872912b7285fa9ce858820cf7799fb335bf5a05561b5e">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MzIdentMLMarshaller.java</strong><dd><code>Enhance marshalling with schema location and date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLMarshaller.java

<li>Add Calendar import for date handling<br> <li> Set schema location property for MzIdentML root elements<br> <li> Auto-set creation date if not defined


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/jmzIdentML/pull/20/files#diff-2a82fca2ab236b68c93db8336ab692525bab40806d28e9f713d04ddfd1bafbb5">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MzIdentMLUnmarshaller.java</strong><dd><code>Add 1.3 version detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/uk/ac/ebi/jmzidml/xml/io/MzIdentMLUnmarshaller.java

<li>Add version 1.3 detection in constructor<br> <li> Handle mzIdentML 1.3 files during unmarshalling


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/jmzIdentML/pull/20/files#diff-93cf9a8376d336702ffadab1e7fdc013a2bc8a6e1962cc4bf977f249e99118cf">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EscapingXMLStreamWriter.java</strong><dd><code>Fix XML attribute prefix handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/uk/ac/ebi/jmzidml/xml/util/EscapingXMLStreamWriter.java

<li>Fix writeAttribute method to use provided prefix instead of empty <br>string


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/jmzIdentML/pull/20/files#diff-b4fd918fb5075a7d788e0632ab9966fffd434dd56bc918a8b0dc216aeb8e35f7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for mzIdentML version 1.3, including recognition of its namespace, version, and schema.
  - Enhanced marshalling functionality to handle mzIdentML 1.3 files, including manual XML header creation and improved root element processing.

- **Bug Fixes**
  - Improved version detection logic for mzIdentML files, ensuring correct handling of version 1.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->